### PR TITLE
Improve distance equation in MixinRendererSorter

### DIFF
--- a/src/main/java/org/embeddedt/archaicfix/mixins/client/core/MixinRenderSorter.java
+++ b/src/main/java/org/embeddedt/archaicfix/mixins/client/core/MixinRenderSorter.java
@@ -17,7 +17,7 @@ public class MixinRenderSorter {
             double xDiff = e.posX - instance.posXPlus;
             double yDiff = e.posY - instance.posYPlus;
             double zDiff = e.posZ - instance.posZPlus;
-            return (float)(xDiff * xDiff + yDiff * yDiff * Minecraft.getMinecraft().gameSettings.renderDistanceChunks / 2 + zDiff * zDiff);
+            return (float)(Math.pow(xDiff, 2) + Math.pow(yDiff * Minecraft.getMinecraft().gameSettings.renderDistanceChunks / 2, 2) + Math.pow(zDiff, 2));
         } else {
             return instance.distanceToEntitySquared(e);
         }


### PR DESCRIPTION
Fixes render distance effectively being square rooted in the distance equation. See commit message for benchmark results (made at 12 chunk render distance).