### PR TITLE
Add mixin to fix NPE from Waystones

### DIFF
--- a/src/main/java/org/embeddedt/archaicfix/asm/Mixin.java
+++ b/src/main/java/org/embeddedt/archaicfix/asm/Mixin.java
@@ -128,6 +128,8 @@ public enum Mixin {
 
     common_foodplus_MixinUpdater(Side.COMMON, Phase.LATE, require(TargetedMod.FOODPLUS).and(m -> ArchaicConfig.disableFoodPlusUpdates), "foodplus.MixinUpdater"),
 
+    common_waystones_MixinItemWarpStone(Side.COMMON, Phase.LATE, require(TargetedMod.WAYSTONES), "waystones.MixinItemWarpStone"),
+
     /** This mixin will ostensibly be unnecessary after DragonAPI V31b */
     common_dragonapi_MixinReikaWorldHelper(Side.COMMON, Phase.LATE, m -> DragonAPIHelper.isVersionInInclusiveRange(0, 'a', 31, 'b') && !Boolean.valueOf(System.getProperty("archaicFix.disableFastReikaWorldHelper", "false")), "dragonapi.MixinReikaWorldHelper"),
 

--- a/src/main/java/org/embeddedt/archaicfix/asm/TargetedMod.java
+++ b/src/main/java/org/embeddedt/archaicfix/asm/TargetedMod.java
@@ -29,6 +29,7 @@ public enum TargetedMod {
     AM2("ArsMagica2", "arsmagica2"),
     FOODPLUS("FoodPlus", "FoodPlus"),
     DIVERSITY("Diversity", "diversity"),
+    WAYSTONES("Waystones", "waystones"),
     AOA("AdventOfAscension", "nevermine")
     ;
 

--- a/src/main/java/org/embeddedt/archaicfix/mixins/common/waystones/MixinItemWarpStone.java
+++ b/src/main/java/org/embeddedt/archaicfix/mixins/common/waystones/MixinItemWarpStone.java
@@ -1,0 +1,21 @@
+package org.embeddedt.archaicfix.mixins.common.waystones;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Pseudo
+@Mixin(targets = "net.blay09.mods.waystones.item.ItemWarpStone")
+public class MixinItemWarpStone {
+    @Inject(method = "getDisplayDamage", at = @At("HEAD"), cancellable = true)
+    public void getDisplayDamage(ItemStack itemStack, CallbackInfoReturnable<Integer> cir) {
+        if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
+            cir.setReturnValue(0);
+            cir.cancel();
+        }
+    }
+}


### PR DESCRIPTION
AE2 calls getDisplayDamage from the server thread during world startup, and the warpstone attempts to load the client player from that method. Since the client player isn't present at that point, it NPEs when it tries to read the player's data.

https://gist.github.com/jeremiahwinsley/24343eaba1b6adc7443776a7fc693d56

https://github.com/TwelveIterationMods/Waystones/blob/8ee576ddf087eb865e45c757cb905151e26ddd40/src/main/java/net/blay09/mods/waystones/item/ItemWarpStone.java#L86