### PR TITLE
Added RPLE compatibility

### DIFF
--- a/repositories.gradle
+++ b/repositories.gradle
@@ -7,13 +7,21 @@ repositories {
         name = "sonatype"
         url = "https://oss.sonatype.org/content/repositories/snapshots/"
     }
-    maven {
-        name "mvnmrtjp"
-        url "http://files.projectredwiki.com/maven"
-        metadataSources {
-            mavenPom()
-            artifact()
+
+    //Not having this causes jitpack to stall builds for minutes on systems without mrtjpcore already cached
+    exclusiveContent {
+        forRepository {
+            maven {
+                name "mvnmrtjp"
+                url "https://files.projectredwiki.com/maven"
+                metadataSources {
+                    mavenPom()
+                    artifact()
+                }
+            }
         }
-        allowInsecureProtocol
+        filter {
+            includeGroup("mrtjp")
+        }
     }
 }

--- a/src/main/java/org/embeddedt/archaicfix/asm/Mixin.java
+++ b/src/main/java/org/embeddedt/archaicfix/asm/Mixin.java
@@ -30,6 +30,7 @@ public enum Mixin {
     common_core_MixinShapedOreRecipe(Side.COMMON, Phase.EARLY, always(), "core.MixinShapedOreRecipe"),
     common_core_MixinLongHashMap(Side.COMMON, Phase.EARLY, always(), "core.MixinLongHashMap"),
     common_core_MixinBlock(Side.COMMON, Phase.EARLY, always(), "core.MixinBlock"),
+    common_core_MixinBlock_Late(Side.COMMON, Phase.EARLY, always(), "core.MixinBlock_Late"),
     common_core_MixinEnchantmentHelper(Side.COMMON, Phase.EARLY, always(), "core.MixinEnchantmentHelper"),
     common_core_MixinWorldChunkManager(Side.COMMON, Phase.EARLY, always(), "core.MixinWorldChunkManager"),
     common_core_MixinShapedRecipes(Side.COMMON, Phase.EARLY, always(), "core.MixinShapedRecipes"),

--- a/src/main/java/org/embeddedt/archaicfix/mixins/common/core/MixinBlock.java
+++ b/src/main/java/org/embeddedt/archaicfix/mixins/common/core/MixinBlock.java
@@ -4,7 +4,6 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
 import net.minecraft.block.Block;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.IBlockAccess;
 import org.embeddedt.archaicfix.block.ThreadedBlockData;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
@@ -56,14 +55,5 @@ public abstract class MixinBlock {
             arch$threadBlockData.set(calculated);
         }
         return calculated;
-    }
-
-    /**
-     * @author embeddedt
-     * @reason Avoid calling getBlock
-     */
-    @Redirect(method = "getLightValue(Lnet/minecraft/world/IBlockAccess;III)I", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/IBlockAccess;getBlock(III)Lnet/minecraft/block/Block;"), require = 0)
-    public Block getLightValue(IBlockAccess world, int x, int y, int z) {
-        return (Block)(Object)this;
     }
 }

--- a/src/main/java/org/embeddedt/archaicfix/mixins/common/core/MixinBlock_Late.java
+++ b/src/main/java/org/embeddedt/archaicfix/mixins/common/core/MixinBlock_Late.java
@@ -1,0 +1,20 @@
+package org.embeddedt.archaicfix.mixins.common.core;
+
+import net.minecraft.block.Block;
+import net.minecraft.world.IBlockAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+//RPLE replaces getLightValue with an overwrite at priority 1000, so this redirect needs to be delayed for mixin to not crash
+@Mixin(value = Block.class, priority = 2000)
+public abstract class MixinBlock_Late {
+    /**
+     * @author embeddedt
+     * @reason Avoid calling getBlock
+     */
+    @Redirect(method = "getLightValue(Lnet/minecraft/world/IBlockAccess;III)I", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/IBlockAccess;getBlock(III)Lnet/minecraft/block/Block;"), expect = 0, require = 0)
+    public Block getLightValue(IBlockAccess world, int x, int y, int z) {
+        return (Block)(Object)this;
+    }
+}


### PR DESCRIPTION
The priority 300 BlockMixin conflicts with RPLE's BlockMixin getLightValue redirect https://github.com/GTMEGA/RPLE/blob/57ae27dcb9891f968e10f7b52fbd4d5b1382d093/src/main/java/com/falsepattern/rple/internal/mixin/mixins/common/BlockMixin.java#L60, this PR moves the conflicting redirect to priority 2000 so that the mixin engine is happy.

The Overwrite is necessary on RPLE's side, as an Inject with a cancel causes extreme object allocation spam, and an ASM transformer is too dirty.

Also fixed a bug in the buildscript that caused mrjtpcore to stall the build for 5 minutes due to a weird jitpack interaction.

Fixing the compat on ArchaicFix's side makes more sense, as AF is a generic hotfix/patch/performance mod while RPLE is a content mod.