### PR TITLE
Add Unimixins 0.1.16+ dep

### DIFF
--- a/src/main/java/org/embeddedt/archaicfix/ArchaicFix.java
+++ b/src/main/java/org/embeddedt/archaicfix/ArchaicFix.java
@@ -24,7 +24,7 @@ import thaumcraft.api.ThaumcraftApi;
 
 import java.util.*;
 
-@Mod(modid = ArchaicFix.MODID, version = ArchaicFix.VERSION, dependencies = "required-after:gtnhmixins@[2.0.0,);", guiFactory = "org.embeddedt.archaicfix.config.ArchaicGuiConfigFactory")
+@Mod(modid = ArchaicFix.MODID, version = ArchaicFix.VERSION, dependencies = "required-after:gtnhmixins@[2.0.0,);required-after:unimixins@[0.1.16,);", guiFactory = "org.embeddedt.archaicfix.config.ArchaicGuiConfigFactory")
 public class ArchaicFix
 {
     public static final String MODID = "archaicfix";

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -11,6 +11,6 @@
   "credits": "The Forge and FML guys, for making this example",
   "logoFile": "",
   "screenshots": [],
-  "dependencies": ["required-after:gtnhmixins@[2.0.0,)"]
+  "dependencies": ["required-after:gtnhmixins@[2.0.0,)", "required-after:unimixins@[0.1.16,)"]
 }
 ]


### PR DESCRIPTION
It bundles mixinextras 0.3.5 which contains an API that the item tick optimization requires.

Previous versions of unimixins would exhibit a similar bug as to archaicfix 0.7.2 and et futurum requiem.

Deciding to do this rather than add the dependency for mixinextras directly as this seemed a bit more foolproof.

Fixes #124 