### PR TITLE
Fix crafting cache being checked for every recipe

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,7 +35,7 @@ dependencies {
     compileOnly(deobfMaven(curseMaven, "curse.maven:journeymap-32274:2367915"))
     compileOnly(deobfMaven(curseMaven, "curse.maven:ars-magica-2-67313:2280862"))
     compileOnly(deobfMaven(curseMaven, "curse.maven:waystones-245755:2559125"))
-    runtimeOnly(deobf("https://github.com/makamys/CoreTweaks/releases/download/0.3.0.4/CoreTweaks-1.7.10-0.3.0.4+nomixin.jar"))
+    runtimeOnly(deobf("https://github.com/makamys/CoreTweaks/releases/download/0.3.3.2/CoreTweaks-1.7.10-0.3.3.2+nomixin.jar"))
 
     if(!Boolean.valueOf(project.properties["archaicFix.noRuntimeExtras"] ?: "false")) {
         runtimeOnly(deobfMaven(curseMaven, "curse.maven:xaerosminimap-263420:3876755"))

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,7 +33,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.29'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.37'
 }
 
 

--- a/src/main/java/org/embeddedt/archaicfix/mixins/common/core/MixinCraftingManager.java
+++ b/src/main/java/org/embeddedt/archaicfix/mixins/common/core/MixinCraftingManager.java
@@ -19,6 +19,7 @@ import org.embeddedt.archaicfix.recipe.RecipeWeigher;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.HashSet;
@@ -35,7 +36,10 @@ public class MixinCraftingManager implements IFasterCraftingManager {
 
     private volatile LastMatchedInfo lastMatchedInfo = null;
 
-    @Inject(method = "findMatchingRecipe", at = @At(value = "INVOKE", target = "Ljava/util/List;size()I"), cancellable = true)
+    @Inject(method = "findMatchingRecipe", at = @At(value = "CONSTANT", args = "intValue=0"), slice = @Slice(
+            from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;<init>(Lnet/minecraft/item/Item;II)V"),
+            to =  @At(value = "INVOKE", target = "Ljava/util/List;size()I")
+    ), cancellable = true)
     private void fasterRecipeSearch(InventoryCrafting inventory, World world, CallbackInfoReturnable<ItemStack> cir) {
         if(!ArchaicConfig.cacheRecipes)
             return;


### PR DESCRIPTION
The injection targeted the list.size() call before, which gets called after before every iteration, which therefore also caused the mixin to run before every iteration, when it should only run once.
Changed it to target the initializer instead, so it only runs once