### PR TITLE
Mixin to fix stack size rendering for AE2 + NEI-GTNH

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     compileOnly files("deps/Food Plus Mod 1.7.10-deobf.jar")
     compileOnly(deobfMaven(curseMaven, "curse.maven:dragonapi-235591:3574508"))
+    compileOnly(deobfMaven(curseMaven, "curse.maven:applied-energistics-2-223794:2296430"))
 
     // Provides deobf support like in FG2
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:CodeChickenLib:1.2.1:dev')

--- a/src/main/java/org/embeddedt/archaicfix/asm/Mixin.java
+++ b/src/main/java/org/embeddedt/archaicfix/asm/Mixin.java
@@ -132,6 +132,8 @@ public enum Mixin {
 
     common_waystones_MixinItemWarpStone(Side.COMMON, Phase.LATE, require(TargetedMod.WAYSTONES), "waystones.MixinItemWarpStone"),
 
+    client_ae2_MixinNEIItemRender(Side.CLIENT, Phase.LATE, require(TargetedMod.AE2).and(m -> ArchaicConfig.disableAE2NEIItemRendering), "ae2.MixinNEIItemRender"),
+
     /** This mixin will ostensibly be unnecessary after DragonAPI V31b */
     common_dragonapi_MixinReikaWorldHelper(Side.COMMON, Phase.LATE, m -> DragonAPIHelper.isVersionInInclusiveRange(0, 'a', 31, 'b') && !Boolean.valueOf(System.getProperty("archaicFix.disableFastReikaWorldHelper", "false")), "dragonapi.MixinReikaWorldHelper"),
 

--- a/src/main/java/org/embeddedt/archaicfix/asm/TargetedMod.java
+++ b/src/main/java/org/embeddedt/archaicfix/asm/TargetedMod.java
@@ -28,6 +28,7 @@ public enum TargetedMod {
     FOODPLUS("FoodPlus", "FoodPlus"),
     DIVERSITY("Diversity", "diversity"),
     WAYSTONES("Waystones", "waystones"),
+    AE2("AppliedEnergistics2", "appliedenergistics2"),
     AOA("AdventOfAscension", "nevermine")
     ;
 

--- a/src/main/java/org/embeddedt/archaicfix/config/ArchaicConfig.java
+++ b/src/main/java/org/embeddedt/archaicfix/config/ArchaicConfig.java
@@ -176,4 +176,8 @@ public class ArchaicConfig {
     @Config.Comment("Make entities drop XP immediately on death, like modern versions")
     @Config.DefaultBoolean(true)
     public static boolean dropXpImmediatelyOnDeath;
+
+    @Config.Comment("Disable NEI item rendering in AE2 to fix duplicate stack size rendering when using AE2 rv3-beta-6 with NEI > 2.6.37-GTNH")
+    @Config.DefaultBoolean(true)
+    public static boolean disableAE2NEIItemRendering;
 }

--- a/src/main/java/org/embeddedt/archaicfix/mixins/client/ae2/MixinNEIItemRender.java
+++ b/src/main/java/org/embeddedt/archaicfix/mixins/client/ae2/MixinNEIItemRender.java
@@ -1,0 +1,26 @@
+package org.embeddedt.archaicfix.mixins.client.ae2;
+
+import appeng.client.gui.AEBaseGui;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.renderer.entity.RenderItem;
+import net.minecraft.inventory.Container;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(AEBaseGui.class)
+public abstract class MixinNEIItemRender extends GuiContainer {
+
+    protected MixinNEIItemRender(Container container) {
+        super(container);
+    }
+
+    // disable the duplicate text rendering for stack sizes in the AE2 GUI when NEI compatibility is enabled
+    @Inject(method = "setItemRender", at = @At("HEAD"), cancellable = true, remap = false)
+    private void setItemRender(RenderItem item, CallbackInfoReturnable<RenderItem> cir) {
+        final RenderItem ri = itemRender;
+        itemRender = item;
+        cir.setReturnValue(ri);
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/GTNewHorizons/NotEnoughItems/issues/537 for AE2 rv3-beta-6 users. This disables the NEI item rendering, without disabling all of the NEI compatibility. Tested in GTNH and seems to be compatible with GTNH AE2 also, so I set the config as enabled by default, feel free to change though.