### PR TITLE
Disable conflicting mixins when Hodgepodge is present

### DIFF
--- a/src/main/java/org/embeddedt/archaicfix/ArchaicCore.java
+++ b/src/main/java/org/embeddedt/archaicfix/ArchaicCore.java
@@ -67,6 +67,7 @@ public class ArchaicCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
             .put("optifine.OptiFineForgeTweaker", TargetedMod.OPTIFINE)
             .put("fastcraft.Tweaker", TargetedMod.FASTCRAFT)
             .put("cofh.asm.LoadingPlugin", TargetedMod.COFHCORE)
+            .put("com.mitchej123.hodgepodge.core.HodgepodgeCore", TargetedMod.HODGEPODGE)
             .build();
 
     private static void detectCoreMods(Set<String> loadedCoreMods) {
@@ -80,12 +81,18 @@ public class ArchaicCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
     public List<String> getMixins(Set<String> loadedCoreMods) {
         List<String> mixins = new ArrayList<>();
         detectCoreMods(loadedCoreMods);
-        LOGGER.info("Detected coremods: [" + coreMods.stream().map(TargetedMod::name).collect(Collectors.joining(", ")) + "]");
-        for(Mixin mixin : Mixin.values()) {
-            if(mixin.getPhase() == Mixin.Phase.EARLY && mixin.shouldLoadSide() && mixin.getFilter().test(coreMods)) {
+        LOGGER.info("Detected coremods: [{}]", coreMods.stream().map(TargetedMod::name).collect(Collectors.joining(", ")));
+        final List<String> notLoading = new ArrayList<>();
+
+        for (Mixin mixin : Mixin.values()) {
+            if (mixin.getPhase() == Mixin.Phase.EARLY && mixin.shouldLoadSide() && mixin.getFilter().test(coreMods)) {
                 mixins.add(mixin.getMixin());
+            } else {
+                notLoading.add(mixin.getMixin());
             }
         }
+
+        LOGGER.info("Not loading the following early mixins: [{}]", String.join(", ", notLoading));
         return mixins;
     }
 }

--- a/src/main/java/org/embeddedt/archaicfix/asm/Mixin.java
+++ b/src/main/java/org/embeddedt/archaicfix/asm/Mixin.java
@@ -38,6 +38,7 @@ public enum Mixin {
     common_core_MixinEntityLiving(Side.COMMON, Phase.EARLY, always(), "core.MixinEntityLiving"),
     common_core_MixinEntityLivingBase_EarlyXpDrop(Side.COMMON, Phase.EARLY, m -> ArchaicConfig.dropXpImmediatelyOnDeath, "core.MixinEntityLivingBase_EarlyXpDrop"),
     common_core_MixinWorld(Side.COMMON, Phase.EARLY, always(), "core.MixinWorld"),
+    common_core_MixinWorld_UpdateEntities(Side.COMMON, Phase.EARLY, avoid(TargetedMod.HODGEPODGE), "core.MixinWorld_UpdateEntities"),
     common_core_MixinEntityTrackerEntry(Side.COMMON, Phase.EARLY, always(), "core.MixinEntityTrackerEntry"),
     common_core_MixinEntityXPOrb(Side.COMMON, Phase.EARLY, always(), "core.MixinEntityXPOrb"),
     common_core_MixinEntityItem(Side.COMMON, Phase.EARLY, avoid(TargetedMod.SHIPSMOD).and(m -> ArchaicConfig.itemLagReduction), "core.MixinEntityItem"),

--- a/src/main/java/org/embeddedt/archaicfix/asm/TargetedMod.java
+++ b/src/main/java/org/embeddedt/archaicfix/asm/TargetedMod.java
@@ -29,7 +29,8 @@ public enum TargetedMod {
     DIVERSITY("Diversity", "diversity"),
     WAYSTONES("Waystones", "waystones"),
     AE2("AppliedEnergistics2", "appliedenergistics2"),
-    AOA("AdventOfAscension", "nevermine")
+    AOA("AdventOfAscension", "nevermine"),
+    HODGEPODGE("Hodgepodge", "hodgepodge")
     ;
 
     @Getter

--- a/src/main/java/org/embeddedt/archaicfix/mixins/common/core/MixinWorld.java
+++ b/src/main/java/org/embeddedt/archaicfix/mixins/common/core/MixinWorld.java
@@ -2,12 +2,13 @@ package org.embeddedt.archaicfix.mixins.common.core;
 
 import com.google.common.collect.ImmutableSet;
 import cpw.mods.fml.common.FMLCommonHandler;
+import java.util.List;
+import java.util.Set;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.World;
@@ -23,12 +24,9 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
-
-import java.util.*;
 
 @Mixin(World.class)
 public abstract class MixinWorld {
@@ -141,18 +139,5 @@ public abstract class MixinWorld {
                 }
             }
         }
-    }
-
-    @Redirect(method = "updateEntities", slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/tileentity/TileEntity;onChunkUnload()V", remap = false)), at = @At(value = "INVOKE", target = "Ljava/util/List;removeAll(Ljava/util/Collection;)Z", ordinal = 0))
-    private boolean removeInUnloaded(List<TileEntity> instance, Collection<TileEntity> objects) {
-        if (ArchaicConfig.fixTEUnloadLag) {
-            // Arbitrary number chosen because contains() will be fast enough on a tiny list
-            if(objects.size() > 3) {
-                Set<TileEntity> toRemove = Collections.newSetFromMap(new IdentityHashMap<>(objects.size()));
-                toRemove.addAll(objects);
-                objects = toRemove;
-            }
-        }
-        return instance.removeAll(objects);
     }
 }

--- a/src/main/java/org/embeddedt/archaicfix/mixins/common/core/MixinWorld_UpdateEntities.java
+++ b/src/main/java/org/embeddedt/archaicfix/mixins/common/core/MixinWorld_UpdateEntities.java
@@ -1,0 +1,30 @@
+package org.embeddedt.archaicfix.mixins.common.core;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import org.embeddedt.archaicfix.config.ArchaicConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+@Mixin(World.class)
+public abstract class MixinWorld_UpdateEntities {
+    @Redirect(method = "updateEntities", slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/tileentity/TileEntity;onChunkUnload()V", remap = false)), at = @At(value = "INVOKE", target = "Ljava/util/List;removeAll(Ljava/util/Collection;)Z", ordinal = 0))
+    private boolean removeInUnloaded(List<TileEntity> instance, Collection<TileEntity> objects) {
+        if (ArchaicConfig.fixTEUnloadLag) {
+            // Arbitrary number chosen because contains() will be fast enough on a tiny list
+            if(objects.size() > 3) {
+                Set<TileEntity> toRemove = Collections.newSetFromMap(new IdentityHashMap<>(objects.size()));
+                toRemove.addAll(objects);
+                objects = toRemove;
+            }
+        }
+        return instance.removeAll(objects);
+    }
+}


### PR DESCRIPTION
Splits off part of `MixinWorld` and disables it when Hodgepodge is present, as Hodgepodge has a better version of the same patch.