### PR TITLE
prevent skip GC mixin in Minecraft#loadWorld from cancelling all the code at the end of the method

### DIFF
--- a/src/main/java/org/embeddedt/archaicfix/mixins/client/core/MixinMinecraft.java
+++ b/src/main/java/org/embeddedt/archaicfix/mixins/client/core/MixinMinecraft.java
@@ -25,8 +25,6 @@ public abstract class MixinMinecraft {
 
     @Shadow public abstract void displayGuiScreen(GuiScreen p_147108_1_);
 
-    @Shadow public GuiScreen currentScreen;
-
     @Shadow private boolean fullscreen;
 
     /** @reason Makes grass display as fancy regardless of the graphics setting. Matches the appearance of 1.8+ */
@@ -35,10 +33,8 @@ public abstract class MixinMinecraft {
         return true;
     }
     /** @reason Removes a call to {@link System#gc()} to make world loading as fast as possible */
-    @Inject(method = "loadWorld(Lnet/minecraft/client/multiplayer/WorldClient;Ljava/lang/String;)V", at = @At(value = "INVOKE", target = "Ljava/lang/System;gc()V"), cancellable = true)
-    private void onSystemGC(WorldClient worldClient, String reason, CallbackInfo ci) {
-        ci.cancel();
-    }
+    @Redirect(method = "loadWorld(Lnet/minecraft/client/multiplayer/WorldClient;Ljava/lang/String;)V", at = @At(value = "INVOKE", target = "Ljava/lang/System;gc()V"))
+    private void onSystemGC() {}
 
     @Inject(method = "checkGLError", at = @At("HEAD"), cancellable = true)
     private void skipErrorCheck(String msg, CallbackInfo ci) {


### PR DESCRIPTION
Currently the cancellable inject skips all the code at the end of the method and not only the system.gc call, I changed it for a redirect to avoid side effects
before:
<img width="799" height="185" alt="image" src="https://github.com/user-attachments/assets/d69e6c87-11b9-4af5-87df-db753476e987" />
after:
<img width="422" height="109" alt="image" src="https://github.com/user-attachments/assets/893f1d6c-8dfe-4cec-8d47-354114a3ef3c" />
